### PR TITLE
start: fix result check when using multiple domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Automatically generates Let's Encrypt certificates using a lightweight Docker co
 
 * `DUCKDNS_TOKEN`: Duck DNS account token (obtained from [Duck DNS](https://www.duckdns.org)) (*required*)
 * `DUCKDNS_DOMAIN`: Full Duck DNS domain (e.g. `test.duckdns.org`) (*required*)
+  * Multiple domains **belonging to the same token** can be entered as a comma-separated list of values (e.g. `test1.duckdns.org,test2.duckdns.org`).
 * `LETSENCRYPT_DOMAIN`: Domain to generate SSL cert for. By default the SSL certificate is generated for `DUCKDNS_DOMAIN` (optional)
 * `LETSENCRYPT_WILDCARD`: `true` or `false`, indicating whether the SSL certificate should be for subdomains *only* of `LETSENCRYPT_DOMAIN` (i.e. `*.test.duckdns.org`), or for the main domain *only* (i.e. `test.duckdns.org`) (optional, default: `false`)
+  * Note: using this in combination with multiple domains will affect only the first domain in the comma-separated list
 * `LETSENCRYPT_EMAIL`: Email used for certificate renewal notifications (optional)
 * `LETSENCRYPT_CHAIN`: Preferred certificate chain (e.g. `ISRG Root X1`, see [https://letsencrypt.org/certificates](https://letsencrypt.org/certificates/) for more details) (optional)
 * `TESTING`: `true` or `false`, indicating whether a staging SSL certificate should be generated or not (optional, default: `false`)

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -93,9 +93,10 @@ certbot certonly --manual --preferred-challenges dns \
 chown -R $UID:$GID /etc/letsencrypt
 
 # Check for successful certificate generation
-if [ ! -d "/etc/letsencrypt/live/${LETSENCRYPT_DOMAIN#\*\.}" ] || \
-   [ ! -f "/etc/letsencrypt/live/${LETSENCRYPT_DOMAIN#\*\.}/fullchain.pem" ] || \
-   [ ! -f "/etc/letsencrypt/live/${LETSENCRYPT_DOMAIN#\*\.}/privkey.pem" ]; then
+DEST_DIR=$(echo "/etc/letsencrypt/live/${LETSENCRYPT_DOMAIN#\*\.}" | cut -d ',' -f1)
+if [ ! -d "$DEST_DIR" ] || \
+   [ ! -f "$DEST_DIR/fullchain.pem" ] || \
+   [ ! -f "$DEST_DIR/privkey.pem" ]; then
   echo "ERROR: Failed to create SSL certificates"
   exit 1
 fi


### PR DESCRIPTION
When using multiple domains (e.g. as a comma-separated list), certbot will store the certificates in a folder named after the first domain.

Citing the docs:

> All domains will be included as Subject Alternative Names on the certificate. The first domain will be used as the certificate name, unless otherwise specified or if you already have a certificate with the same name. In the case of a name conflict, a number like -0001 will be appended to the certificate name